### PR TITLE
Add branch to use org-jira's restapi branch instead of old SOAP API

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -10,12 +10,17 @@
 ;;
 ;;; License: GPLv3
 
-(defvar org-jira-packages '(org org-jira))
+(defvar org-jira-packages '(org
+                            (org-jira :location (recipe
+                                                 :fetcher github
+                                                 :repo "baohaojun/org-jira"
+                                                 :branch "restapi"))))
 
 (defvar org-jira-excluded-packages '() "List of packages to exclude.")
 
 (defun org-jira/init-org-jira ()
   (use-package org-jira
+    :defer t
     :config
     (progn
       (spacemacs/declare-prefix-for-mode 'org-mode "mj" "jira")


### PR DESCRIPTION
Newer versions of JIRA use a REST API instead of the old SOAP API. The `org-jira` emacs package has a `restapi` branch that uses the REST API. I suggest having a `restapi` branch in this repo as well, so that one easily can use the REST API if necessary.
