### PR TITLE
Change ahungry/org-jira branch to master

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -14,7 +14,7 @@
                             (org-jira :location (recipe
                                                  :fetcher github
                                                  :repo "ahungry/org-jira"
-                                                 :branch "restapi"))))
+                                                 :branch "master"))))
 
 (defvar org-jira-excluded-packages '() "List of packages to exclude.")
 


### PR DESCRIPTION
The `restapi` branch doesn't exisits in [ahungry/org-jira](https://github.com/ahungry/org-jira/branches/all)