### PR TITLE
Install org-jira from MELPA instead of GitHub.

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -11,10 +11,7 @@
 ;;; License: GPLv3
 
 (defvar org-jira-packages '(org
-                            (org-jira :location (recipe
-                                                 :fetcher github
-                                                 :repo "ahungry/org-jira"
-                                                 :branch "restapi"))))
+                            (org-jira :location elpa)))
 
 (defvar org-jira-excluded-packages '() "List of packages to exclude.")
 


### PR DESCRIPTION
MELPA version seems to be up to date.
Installation over GitHub didn't work for me, nor some guys I consulted on Spacemacs Gitter channel.