### PR TITLE
Moved ORG dependency to layer level instead of package.

### DIFF
--- a/layers.el
+++ b/layers.el
@@ -1,0 +1,1 @@
+(configuration-layer/declare-layer 'org)

--- a/packages.el
+++ b/packages.el
@@ -10,8 +10,7 @@
 ;;
 ;;; License: GPLv3
 
-(defvar org-jira-packages '(org
-                            (org-jira :location elpa)))
+(defvar org-jira-packages '((org-jira :location elpa)))
 
 (defvar org-jira-excluded-packages '() "List of packages to exclude.")
 

--- a/packages.el
+++ b/packages.el
@@ -11,10 +11,7 @@
 ;;; License: GPLv3
 
 (defvar org-jira-packages '(org
-                            (org-jira :location (recipe
-                                                 :fetcher github
-                                                 :repo "ahungry/org-jira"
-                                                 :branch "restapi"))))
+                            (org-jira :location elpa)))
 
 (defvar org-jira-excluded-packages '() "List of packages to exclude.")
 


### PR DESCRIPTION
Current setup leads to warning at Spacemacs start:
> package org not initialized in layer org-jira, you may consider removing this
> package from the package list or use the :toggle keyword instead of a `when'
> form. 

This is due to _org_ package begin listed in _org-jira-packages_ but not being initialized.
Not to mess with the initialization of the package / org layer setup, I decided to use _configuration-layer/declare-layer_ function to establish a dependency between org-jira layer and org layer.

Now if you enable org-jira layer in your _.spacemacs_, _org_ layer gets implicitly enabled if it was not enabled explicitly.