### PR TITLE
Fix initialization of keymaps

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -17,7 +17,7 @@
 (defun org-jira/init-org-jira ()
   (use-package org-jira
     :defer t
-    :config
+    :init
     (progn
       (spacemacs/declare-prefix-for-mode 'org-mode "mj" "jira")
       (spacemacs/declare-prefix-for-mode 'org-mode "mjp" "projects")


### PR DESCRIPTION
Moved the key binding to the init section, as otherwise they would only be visible after org-jira has been loaded.